### PR TITLE
refactor(api): extract classroom presenter and current-group service

### DIFF
--- a/api/src/lib/tenant-access.ts
+++ b/api/src/lib/tenant-access.ts
@@ -30,9 +30,15 @@ export function isOpenPathGroupEnabled(value: unknown): boolean {
 
 export type GroupAccessLevel = 'view' | 'edit';
 
-export async function assertOrgGroupAccess(organizationId: string, groupId: string): Promise<void> {
+export async function getOrgGroupLinkOrThrow(
+  organizationId: string,
+  groupId: string
+): Promise<{ id: string; visibility: string }> {
   const orgGroup = await db
-    .select({ id: schema.cpOrganizationGroups.id })
+    .select({
+      id: schema.cpOrganizationGroups.id,
+      visibility: schema.cpOrganizationGroups.visibility,
+    })
     .from(schema.cpOrganizationGroups)
     .where(
       and(
@@ -42,12 +48,19 @@ export async function assertOrgGroupAccess(organizationId: string, groupId: stri
     )
     .limit(1);
 
-  if (!orgGroup.length) {
+  const row = orgGroup[0];
+  if (!row) {
     throw new TRPCError({
       code: 'NOT_FOUND',
       message: 'Group not found or access denied',
     });
   }
+
+  return row;
+}
+
+export async function assertOrgGroupAccess(organizationId: string, groupId: string): Promise<void> {
+  await getOrgGroupLinkOrThrow(organizationId, groupId);
 }
 
 export async function assertOrgClassroomAccess(
@@ -163,23 +176,7 @@ export async function assertCanAccessGroup(
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Missing organizationId' });
   }
 
-  const orgGroup = await db
-    .select({ visibility: schema.cpOrganizationGroups.visibility })
-    .from(schema.cpOrganizationGroups)
-    .where(
-      and(
-        eq(schema.cpOrganizationGroups.organizationId, organizationId),
-        eq(schema.cpOrganizationGroups.groupId, groupId)
-      )
-    )
-    .limit(1);
-
-  if (!orgGroup.length) {
-    throw new TRPCError({
-      code: 'NOT_FOUND',
-      message: 'Group not found or access denied',
-    });
-  }
+  const orgGroup = await getOrgGroupLinkOrThrow(organizationId, groupId);
 
   if (isOrgAdmin(ctx)) return;
 
@@ -190,7 +187,7 @@ export async function assertCanAccessGroup(
     });
   }
 
-  if (access === 'view' && orgGroup[0].visibility === 'instance_public') return;
+  if (access === 'view' && orgGroup.visibility === 'instance_public') return;
 
   const ok = await teacherCanUseGroup({ userId: ctx.user.sub, groupId });
   if (!ok) {

--- a/api/src/services/classroom-presenter.ts
+++ b/api/src/services/classroom-presenter.ts
@@ -1,0 +1,151 @@
+import {
+  calculateClassroomMachineStatus,
+  calculateClassroomStatus,
+  resolveCurrentGroup,
+} from '@openpath/shared';
+
+export type MachineStatus = ReturnType<typeof calculateClassroomMachineStatus>;
+
+export type ClassroomMachineListItem = {
+  id: string;
+  hostname: string;
+  classroomId: string;
+  version: string | null;
+  lastSeen: string | null;
+  status: MachineStatus;
+};
+
+export type OpenPathMachineRowForList = {
+  id: string;
+  hostname: string;
+  classroomId: string | null;
+  version: string | null;
+  lastSeen: Date | null;
+};
+
+export function presentMachineForClassroomList(
+  machine: OpenPathMachineRowForList,
+  now: Date
+): ClassroomMachineListItem | null {
+  const classroomId = machine.classroomId;
+  if (!classroomId) return null;
+
+  return {
+    id: machine.id,
+    hostname: machine.hostname,
+    classroomId,
+    version: machine.version,
+    lastSeen: machine.lastSeen?.toISOString?.() ?? null,
+    status: calculateClassroomMachineStatus(machine.lastSeen ?? null, now),
+  };
+}
+
+export function groupMachinesByClassroomIdForList(
+  machineRows: OpenPathMachineRowForList[],
+  now: Date
+): Map<string, ClassroomMachineListItem[]> {
+  const machinesByClassroomId = new Map<string, ClassroomMachineListItem[]>();
+
+  for (const m of machineRows) {
+    const item = presentMachineForClassroomList(m, now);
+    if (!item) continue;
+
+    const list = machinesByClassroomId.get(item.classroomId) ?? [];
+    list.push(item);
+    machinesByClassroomId.set(item.classroomId, list);
+  }
+
+  return machinesByClassroomId;
+}
+
+export type OpenPathClassroomRowForPresent = {
+  id: string;
+  name: string;
+  displayName: string | null;
+  defaultGroupId: string | null;
+  activeGroupId: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+};
+
+export function toPublicClassroomName(classroom: {
+  name: string;
+  displayName: string | null;
+}): string {
+  const displayName = classroom.displayName?.trim();
+  if (displayName) return displayName;
+
+  const scopedMatch = classroom.name.match(/^cp-[a-f0-9]{10}-(.*)-[a-f0-9]{8}$/);
+  return scopedMatch?.[1] ?? classroom.name;
+}
+
+export function presentClassroomBase(params: {
+  classroom: OpenPathClassroomRowForPresent;
+  scheduleGroupId: string | null;
+}): {
+  id: string;
+  name: string;
+  displayName: string | null;
+  defaultGroupId: string | null;
+  activeGroupId: string | null;
+  currentGroupId: string | null;
+  currentGroupSource: ReturnType<typeof resolveCurrentGroup>['source'];
+  createdAt: string | null;
+  updatedAt: string | null;
+} {
+  const c = params.classroom;
+  const currentGroup = resolveCurrentGroup({
+    activeGroupId: c.activeGroupId ?? null,
+    scheduleGroupId: params.scheduleGroupId,
+    defaultGroupId: c.defaultGroupId ?? null,
+  });
+
+  return {
+    id: c.id,
+    name: toPublicClassroomName(c),
+    displayName: c.displayName,
+    defaultGroupId: c.defaultGroupId,
+    activeGroupId: c.activeGroupId,
+    currentGroupId: currentGroup.id,
+    currentGroupSource: currentGroup.source,
+    createdAt: c.createdAt?.toISOString() ?? null,
+    updatedAt: c.updatedAt?.toISOString() ?? null,
+  };
+}
+
+export function presentClassroomListItem(params: {
+  classroom: OpenPathClassroomRowForPresent;
+  scheduleGroupId: string | null;
+  machines: ClassroomMachineListItem[];
+}): {
+  id: string;
+  name: string;
+  displayName: string | null;
+  defaultGroupId: string | null;
+  activeGroupId: string | null;
+  currentGroupId: string | null;
+  currentGroupSource: ReturnType<typeof resolveCurrentGroup>['source'];
+  machines: ClassroomMachineListItem[];
+  machineCount: number;
+  status: ReturnType<typeof calculateClassroomStatus>;
+  onlineMachineCount: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+} {
+  const base = presentClassroomBase({
+    classroom: params.classroom,
+    scheduleGroupId: params.scheduleGroupId,
+  });
+
+  const machines = params.machines;
+  const onlineMachineCount = machines.filter((m) => m.status === 'online').length;
+  const status = calculateClassroomStatus(machines);
+
+  return {
+    ...base,
+    machines,
+    machineCount: machines.length,
+    status,
+    onlineMachineCount,
+  };
+}

--- a/api/src/services/current-group.service.ts
+++ b/api/src/services/current-group.service.ts
@@ -1,0 +1,262 @@
+import { TRPCError } from '@trpc/server';
+import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
+
+import { openpathDb, schedules } from '../db/openpath.js';
+
+// Scheduling uses dayOfWeek + start/end times without timezone.
+// To make "current schedule" deterministic in Docker (which often defaults to UTC),
+// we compute "now" in an explicit timezone.
+const SCHEDULE_TIMEZONE = process.env.SCHEDULE_TIMEZONE || process.env.TZ || 'Europe/Madrid';
+
+const WEEKDAY_BY_SHORT_EN: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+export function getScheduleClock(date: Date): { dayOfWeek: number; timeHHMM: string } {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: SCHEDULE_TIMEZONE,
+      weekday: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).formatToParts(date);
+
+    const weekday = parts.find((p) => p.type === 'weekday')?.value;
+    const hourPartRaw = parts.find((p) => p.type === 'hour')?.value;
+    const minutePart = parts.find((p) => p.type === 'minute')?.value;
+
+    const dayOfWeek =
+      weekday && WEEKDAY_BY_SHORT_EN[weekday] !== undefined
+        ? WEEKDAY_BY_SHORT_EN[weekday]
+        : date.getDay();
+    const hourPart = hourPartRaw === '24' ? '00' : hourPartRaw;
+    const timeHHMM =
+      hourPart && minutePart ? `${hourPart}:${minutePart}` : date.toTimeString().slice(0, 5);
+
+    return { dayOfWeek, timeHHMM };
+  } catch {
+    return { dayOfWeek: date.getDay(), timeHHMM: date.toTimeString().slice(0, 5) };
+  }
+}
+
+export function normalizeTimeHHMM(t: string | null): string {
+  const parts = String(t).split(':');
+  const hh = parts[0];
+  const mm = parts[1];
+  if (hh !== undefined && mm !== undefined) return `${hh}:${mm}`;
+  return String(t);
+}
+
+export function parseTimeToMinutes(t: string): number {
+  const parts = String(t).split(':');
+  const hh = parts[0];
+  const mm = parts[1];
+  const h = Number(hh);
+  const m = Number(mm);
+  if (!Number.isFinite(h) || !Number.isFinite(m)) return NaN;
+  return h * 60 + m;
+}
+
+function weeklyRecurrenceWhereClause() {
+  return or(eq(schedules.recurrence, 'weekly'), isNull(schedules.recurrence));
+}
+
+export async function getCurrentWeeklyScheduleGroupId(params: {
+  classroomId: string;
+  date?: Date | undefined;
+}): Promise<string | null> {
+  const date = params.date ?? new Date();
+  const { dayOfWeek, timeHHMM } = getScheduleClock(date);
+
+  // Only Mon-Fri scheduling is supported
+  if (dayOfWeek === 0 || dayOfWeek === 6) return null;
+
+  const rows = await openpathDb
+    .select({ groupId: schedules.groupId })
+    .from(schedules)
+    .where(
+      and(
+        eq(schedules.classroomId, params.classroomId),
+        weeklyRecurrenceWhereClause(),
+        eq(schedules.dayOfWeek, dayOfWeek),
+        sql`${schedules.startTime} <= ${timeHHMM}::time`,
+        sql`${schedules.endTime} > ${timeHHMM}::time`
+      )
+    )
+    .limit(1);
+
+  return rows[0]?.groupId ?? null;
+}
+
+export async function getCurrentOneOffScheduleGroupId(params: {
+  classroomId: string;
+  date?: Date | undefined;
+}): Promise<string | null> {
+  const date = params.date ?? new Date();
+
+  const rows = await openpathDb
+    .select({ groupId: schedules.groupId })
+    .from(schedules)
+    .where(
+      and(
+        eq(schedules.classroomId, params.classroomId),
+        eq(schedules.recurrence, 'one_off'),
+        sql`${schedules.startAt} <= ${date} AND ${schedules.endAt} > ${date}`
+      )
+    )
+    .limit(1);
+
+  return rows[0]?.groupId ?? null;
+}
+
+export async function getCurrentScheduleGroupId(params: {
+  classroomId: string;
+  date?: Date | undefined;
+}): Promise<string | null> {
+  const oneOff = await getCurrentOneOffScheduleGroupId(params);
+  if (oneOff) return oneOff;
+  return getCurrentWeeklyScheduleGroupId(params);
+}
+
+export async function getCurrentScheduleGroupByClassroomId(params: {
+  classroomIds: string[];
+  date?: Date | undefined;
+}): Promise<Map<string, string>> {
+  const date = params.date ?? new Date();
+  const classroomIds = params.classroomIds;
+  const scheduleGroupByClassroomId = new Map<string, string>();
+
+  if (classroomIds.length === 0) return scheduleGroupByClassroomId;
+
+  // One-off schedules (date/time based) can be active on weekends.
+  const activeOneOffRows = await openpathDb
+    .select({ classroomId: schedules.classroomId, groupId: schedules.groupId })
+    .from(schedules)
+    .where(
+      and(
+        inArray(schedules.classroomId, classroomIds),
+        eq(schedules.recurrence, 'one_off'),
+        sql`${schedules.startAt} <= ${date} AND ${schedules.endAt} > ${date}`
+      )
+    );
+
+  for (const row of activeOneOffRows) {
+    if (!scheduleGroupByClassroomId.has(row.classroomId)) {
+      scheduleGroupByClassroomId.set(row.classroomId, row.groupId);
+    }
+  }
+
+  const { dayOfWeek, timeHHMM } = getScheduleClock(date);
+  if (dayOfWeek === 0 || dayOfWeek === 6) return scheduleGroupByClassroomId;
+
+  const activeWeeklyRows = await openpathDb
+    .select({ classroomId: schedules.classroomId, groupId: schedules.groupId })
+    .from(schedules)
+    .where(
+      and(
+        inArray(schedules.classroomId, classroomIds),
+        weeklyRecurrenceWhereClause(),
+        eq(schedules.dayOfWeek, dayOfWeek),
+        sql`${schedules.startTime} <= ${timeHHMM}::time`,
+        sql`${schedules.endTime} > ${timeHHMM}::time`
+      )
+    );
+
+  for (const row of activeWeeklyRows) {
+    // One-off schedules override weekly schedules.
+    if (!scheduleGroupByClassroomId.has(row.classroomId)) {
+      scheduleGroupByClassroomId.set(row.classroomId, row.groupId);
+    }
+  }
+
+  return scheduleGroupByClassroomId;
+}
+
+export function calculateWeeklyScheduleExpiresAt(params: {
+  now: Date;
+  nowTimeHHMM: string;
+  endTime: string | null;
+}): Date {
+  const endHHMM = normalizeTimeHHMM(params.endTime);
+  const nowMin = parseTimeToMinutes(params.nowTimeHHMM);
+  const endMin = parseTimeToMinutes(endHHMM);
+  if (!Number.isFinite(nowMin) || !Number.isFinite(endMin) || endMin <= nowMin) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid schedule end time' });
+  }
+
+  const msIntoMinute = params.now.getSeconds() * 1000 + params.now.getMilliseconds();
+  return new Date(params.now.getTime() - msIntoMinute + (endMin - nowMin) * 60_000);
+}
+
+export async function resolveActiveScheduleExpiresAt(params: {
+  classroomId: string;
+  scheduleId: string;
+  now: Date;
+}): Promise<Date> {
+  const { classroomId, scheduleId, now } = params;
+
+  const activeOneOffRows = await openpathDb
+    .select({ endAt: schedules.endAt })
+    .from(schedules)
+    .where(
+      and(
+        eq(schedules.id, scheduleId),
+        eq(schedules.classroomId, classroomId),
+        eq(schedules.recurrence, 'one_off'),
+        sql`${schedules.startAt} <= ${now} AND ${schedules.endAt} > ${now}`
+      )
+    )
+    .limit(1);
+
+  const activeOneOff = activeOneOffRows[0];
+  if (activeOneOff) {
+    if (!activeOneOff.endAt) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Invalid one-off schedule end time',
+      });
+    }
+    return activeOneOff.endAt;
+  }
+
+  const { dayOfWeek, timeHHMM } = getScheduleClock(now);
+  if (dayOfWeek === 0 || dayOfWeek === 6) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Schedules are inactive on weekends',
+    });
+  }
+
+  const scheduleRows = await openpathDb
+    .select({ endTime: schedules.endTime })
+    .from(schedules)
+    .where(
+      and(
+        eq(schedules.id, scheduleId),
+        eq(schedules.classroomId, classroomId),
+        weeklyRecurrenceWhereClause(),
+        eq(schedules.dayOfWeek, dayOfWeek),
+        sql`${schedules.startTime} <= ${timeHHMM}::time`,
+        sql`${schedules.endTime} > ${timeHHMM}::time`
+      )
+    )
+    .limit(1);
+
+  const schedule = scheduleRows[0];
+  if (!schedule) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Schedule is not active' });
+  }
+
+  return calculateWeeklyScheduleExpiresAt({
+    now,
+    nowTimeHHMM: timeHHMM,
+    endTime: schedule.endTime,
+  });
+}

--- a/api/src/trpc/routers/classrooms.ts
+++ b/api/src/trpc/routers/classrooms.ts
@@ -4,23 +4,28 @@ import { TRPCError } from '@trpc/server';
 import { router, tenantProcedure } from '../trpc.js';
 import { db } from '../../db/index.js';
 import * as schema from '../../db/schema.js';
-import { and, eq, gt, inArray, isNull, or, sql } from 'drizzle-orm';
+import { and, eq, gt, inArray } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
-
-import {
-  calculateClassroomMachineStatus as calculateMachineStatus,
-  calculateClassroomStatus,
-  resolveCurrentGroup,
-} from '@openpath/shared';
 
 import {
   openpathDb,
   notifyOpenPathClassroomChanged,
   classrooms,
   machines,
-  schedules,
   machineExemptions,
 } from '../../db/openpath.js';
+
+import {
+  getCurrentScheduleGroupByClassroomId,
+  getCurrentScheduleGroupId,
+  resolveActiveScheduleExpiresAt,
+} from '../../services/current-group.service.js';
+
+import {
+  groupMachinesByClassroomIdForList,
+  presentClassroomBase,
+  presentClassroomListItem,
+} from '../../services/classroom-presenter.js';
 
 import {
   assertCanUseGroup,
@@ -31,153 +36,6 @@ import {
 } from '../../lib/tenant-access.js';
 
 const CLASSROOM_SCOPE_PREFIX = 'cp';
-
-// Scheduling uses dayOfWeek + start/end times without timezone.
-// To make "current schedule" deterministic in Docker (which often defaults to UTC),
-// we compute "now" in an explicit timezone.
-const SCHEDULE_TIMEZONE = process.env.SCHEDULE_TIMEZONE || process.env.TZ || 'Europe/Madrid';
-
-const WEEKDAY_BY_SHORT_EN: Record<string, number> = {
-  Sun: 0,
-  Mon: 1,
-  Tue: 2,
-  Wed: 3,
-  Thu: 4,
-  Fri: 5,
-  Sat: 6,
-};
-
-function getScheduleClock(date: Date): { dayOfWeek: number; timeHHMM: string } {
-  try {
-    const parts = new Intl.DateTimeFormat('en-US', {
-      timeZone: SCHEDULE_TIMEZONE,
-      weekday: 'short',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    }).formatToParts(date);
-
-    const weekday = parts.find((p) => p.type === 'weekday')?.value;
-    const hourPartRaw = parts.find((p) => p.type === 'hour')?.value;
-    const minutePart = parts.find((p) => p.type === 'minute')?.value;
-
-    const dayOfWeek =
-      weekday && WEEKDAY_BY_SHORT_EN[weekday] !== undefined
-        ? WEEKDAY_BY_SHORT_EN[weekday]
-        : date.getDay();
-    const hourPart = hourPartRaw === '24' ? '00' : hourPartRaw;
-    const timeHHMM =
-      hourPart && minutePart ? `${hourPart}:${minutePart}` : date.toTimeString().slice(0, 5);
-
-    return { dayOfWeek, timeHHMM };
-  } catch {
-    return { dayOfWeek: date.getDay(), timeHHMM: date.toTimeString().slice(0, 5) };
-  }
-}
-
-type MachineStatus = ReturnType<typeof calculateMachineStatus>;
-
-type ClassroomMachineListItem = {
-  id: string;
-  hostname: string;
-  classroomId: string;
-  version: string | null;
-  lastSeen: string | null;
-  status: MachineStatus;
-};
-
-function normalizeTimeHHMM(t: string | null): string {
-  const parts = String(t).split(':');
-  const hh = parts[0];
-  const mm = parts[1];
-  if (hh !== undefined && mm !== undefined) return `${hh}:${mm}`;
-  return String(t);
-}
-
-function weeklyRecurrenceWhereClause() {
-  return or(eq(schedules.recurrence, 'weekly'), isNull(schedules.recurrence));
-}
-
-async function resolveActiveScheduleExpiresAt(params: {
-  classroomId: string;
-  scheduleId: string;
-  now: Date;
-}): Promise<Date> {
-  const { classroomId, scheduleId, now } = params;
-
-  // One-off schedules (date/time based) can be active on weekends.
-  const activeOneOffRows = await openpathDb
-    .select({ endAt: schedules.endAt })
-    .from(schedules)
-    .where(
-      and(
-        eq(schedules.id, scheduleId),
-        eq(schedules.classroomId, classroomId),
-        eq(schedules.recurrence, 'one_off'),
-        sql`${schedules.startAt} <= ${now} AND ${schedules.endAt} > ${now}`
-      )
-    )
-    .limit(1);
-
-  const activeOneOff = activeOneOffRows[0];
-  if (activeOneOff) {
-    if (!activeOneOff.endAt) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Invalid one-off schedule end time',
-      });
-    }
-    return activeOneOff.endAt;
-  }
-
-  const { dayOfWeek, timeHHMM } = getScheduleClock(now);
-  if (dayOfWeek === 0 || dayOfWeek === 6) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Schedules are inactive on weekends',
-    });
-  }
-
-  const scheduleRows = await openpathDb
-    .select({ endTime: schedules.endTime })
-    .from(schedules)
-    .where(
-      and(
-        eq(schedules.id, scheduleId),
-        eq(schedules.classroomId, classroomId),
-        weeklyRecurrenceWhereClause(),
-        eq(schedules.dayOfWeek, dayOfWeek),
-        sql`${schedules.startTime} <= ${timeHHMM}::time`,
-        sql`${schedules.endTime} > ${timeHHMM}::time`
-      )
-    )
-    .limit(1);
-
-  const schedule = scheduleRows[0];
-  if (!schedule) {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Schedule is not active' });
-  }
-
-  const endHHMM = normalizeTimeHHMM(schedule.endTime);
-  const nowMin = parseTimeToMinutes(timeHHMM);
-  const endMin = parseTimeToMinutes(endHHMM);
-  if (!Number.isFinite(nowMin) || !Number.isFinite(endMin) || endMin <= nowMin) {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid schedule end time' });
-  }
-
-  const msIntoMinute = now.getSeconds() * 1000 + now.getMilliseconds();
-  return new Date(now.getTime() - msIntoMinute + (endMin - nowMin) * 60_000);
-}
-
-function parseTimeToMinutes(t: string): number {
-  const parts = String(t).split(':');
-  const hh = parts[0];
-  const mm = parts[1];
-  const h = Number(hh);
-  const m = Number(mm);
-  if (!Number.isFinite(h) || !Number.isFinite(m)) return NaN;
-  return h * 60 + m;
-}
 
 function normalizeClassroomKey(rawName: string): string {
   return rawName
@@ -209,66 +67,6 @@ function scopedClassroomNameForOrg(organizationId: string, publicName: string): 
   return `${prefix}${base}${suffix}`;
 }
 
-function toPublicClassroomName(classroom: { name: string; displayName: string | null }): string {
-  const displayName = classroom.displayName?.trim();
-  if (displayName) {
-    return displayName;
-  }
-
-  const scopedMatch = classroom.name.match(/^cp-[a-f0-9]{10}-(.*)-[a-f0-9]{8}$/);
-  return scopedMatch?.[1] ?? classroom.name;
-}
-
-async function getCurrentScheduleGroupId(params: {
-  classroomId: string;
-  date?: Date | undefined;
-}): Promise<string | null> {
-  const date = params.date ?? new Date();
-  const { dayOfWeek, timeHHMM } = getScheduleClock(date);
-
-  // Only Mon-Fri scheduling is supported
-  if (dayOfWeek === 0 || dayOfWeek === 6) return null;
-
-  const currentTime = timeHHMM;
-
-  const rows = await openpathDb
-    .select({ groupId: schedules.groupId })
-    .from(schedules)
-    .where(
-      and(
-        eq(schedules.classroomId, params.classroomId),
-        weeklyRecurrenceWhereClause(),
-        eq(schedules.dayOfWeek, dayOfWeek),
-        sql`${schedules.startTime} <= ${currentTime}::time`,
-        sql`${schedules.endTime} > ${currentTime}::time`
-      )
-    )
-    .limit(1);
-
-  return rows[0]?.groupId ?? null;
-}
-
-async function getCurrentOneOffScheduleGroupId(params: {
-  classroomId: string;
-  date?: Date | undefined;
-}): Promise<string | null> {
-  const date = params.date ?? new Date();
-
-  const rows = await openpathDb
-    .select({ groupId: schedules.groupId })
-    .from(schedules)
-    .where(
-      and(
-        eq(schedules.classroomId, params.classroomId),
-        eq(schedules.recurrence, 'one_off'),
-        sql`${schedules.startAt} <= ${date} AND ${schedules.endAt} > ${date}`
-      )
-    )
-    .limit(1);
-
-  return rows[0]?.groupId ?? null;
-}
-
 const CreateClassroomSchema = z.object({
   name: z.string().min(1).max(100),
   displayName: z.string().min(1).max(255).optional(),
@@ -298,106 +96,25 @@ export const classroomsRouter = router({
       .where(inArray(classrooms.id, classroomIds));
 
     const now = new Date();
-    const { dayOfWeek: nowDayOfWeek, timeHHMM: nowTime } = getScheduleClock(now);
-
-    const oneOffGroupByClassroomId = new Map<string, string>();
-    const activeOneOffRows = await openpathDb
-      .select({ classroomId: schedules.classroomId, groupId: schedules.groupId })
-      .from(schedules)
-      .where(
-        and(
-          inArray(schedules.classroomId, classroomIds),
-          eq(schedules.recurrence, 'one_off'),
-          sql`${schedules.startAt} <= ${now} AND ${schedules.endAt} > ${now}`
-        )
-      );
-
-    for (const row of activeOneOffRows) {
-      if (!oneOffGroupByClassroomId.has(row.classroomId)) {
-        oneOffGroupByClassroomId.set(row.classroomId, row.groupId);
-      }
-    }
-
-    const scheduleGroupByClassroomId = new Map<string, string>();
-    if (nowDayOfWeek !== 0 && nowDayOfWeek !== 6) {
-      const activeScheduleRows = await openpathDb
-        .select({ classroomId: schedules.classroomId, groupId: schedules.groupId })
-        .from(schedules)
-        .where(
-          and(
-            inArray(schedules.classroomId, classroomIds),
-            weeklyRecurrenceWhereClause(),
-            eq(schedules.dayOfWeek, nowDayOfWeek),
-            sql`${schedules.startTime} <= ${nowTime}::time`,
-            sql`${schedules.endTime} > ${nowTime}::time`
-          )
-        );
-
-      for (const row of activeScheduleRows) {
-        if (!scheduleGroupByClassroomId.has(row.classroomId)) {
-          scheduleGroupByClassroomId.set(row.classroomId, row.groupId);
-        }
-      }
-    }
+    const scheduleGroupByClassroomId = await getCurrentScheduleGroupByClassroomId({
+      classroomIds,
+      date: now,
+    });
 
     const machineRows = await openpathDb
       .select()
       .from(machines)
       .where(inArray(machines.classroomId, classroomIds));
 
-    const machinesByClassroomId = new Map<string, ClassroomMachineListItem[]>();
-    for (const m of machineRows) {
-      const classroomId = m.classroomId;
-      if (!classroomId) continue;
+    const machinesByClassroomId = groupMachinesByClassroomIdForList(machineRows, now);
 
-      const status = calculateMachineStatus(m.lastSeen ?? null, now);
-      const item: ClassroomMachineListItem = {
-        id: m.id,
-        hostname: m.hostname,
-        classroomId,
-        version: m.version,
-        lastSeen: m.lastSeen?.toISOString?.() ?? null,
-        status,
-      };
-
-      const list = machinesByClassroomId.get(classroomId) ?? [];
-      list.push(item);
-      machinesByClassroomId.set(classroomId, list);
-    }
-
-    // Serialize Date fields for JSON compatibility
-      return result.map((c) => {
-        const oneOffGroupId = oneOffGroupByClassroomId.get(c.id) ?? null;
-        const scheduleGroupId = scheduleGroupByClassroomId.get(c.id) ?? null;
-
-      const currentGroup = resolveCurrentGroup({
-        activeGroupId: c.activeGroupId ?? null,
-        scheduleGroupId: oneOffGroupId ?? scheduleGroupId,
-        defaultGroupId: c.defaultGroupId ?? null,
-      });
-      const currentGroupId = currentGroup.id;
-      const currentGroupSource = currentGroup.source;
-
-      const machinesList = machinesByClassroomId.get(c.id) ?? [];
-      const onlineMachineCount = machinesList.filter((m) => m.status === 'online').length;
-      const status = calculateClassroomStatus(machinesList);
-
-      return {
-        id: c.id,
-        name: toPublicClassroomName(c),
-        displayName: c.displayName,
-        defaultGroupId: c.defaultGroupId,
-        activeGroupId: c.activeGroupId,
-        currentGroupId,
-        currentGroupSource,
-        machines: machinesList,
-        machineCount: machinesList.length,
-        status,
-        onlineMachineCount,
-        createdAt: c.createdAt?.toISOString() ?? null,
-        updatedAt: c.updatedAt?.toISOString() ?? null,
-      };
-    });
+    return result.map((c) =>
+      presentClassroomListItem({
+        classroom: c,
+        scheduleGroupId: scheduleGroupByClassroomId.get(c.id) ?? null,
+        machines: machinesByClassroomId.get(c.id) ?? [],
+      })
+    );
   }),
 
   getById: tenantProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
@@ -412,31 +129,9 @@ export const classroomsRouter = router({
     if (!classroom[0]) return null;
 
     const c = classroom[0];
-    const currentOneOffScheduleGroupId = await getCurrentOneOffScheduleGroupId({
-      classroomId: c.id,
-    });
-    const currentScheduleGroupId = await getCurrentScheduleGroupId({ classroomId: c.id });
+    const scheduleGroupId = await getCurrentScheduleGroupId({ classroomId: c.id });
 
-    const currentGroup = resolveCurrentGroup({
-      activeGroupId: c.activeGroupId ?? null,
-      scheduleGroupId: currentOneOffScheduleGroupId ?? currentScheduleGroupId,
-      defaultGroupId: c.defaultGroupId ?? null,
-    });
-    const currentGroupId = currentGroup.id;
-    const currentGroupSource = currentGroup.source;
-
-    // Serialize Date fields for JSON compatibility
-    return {
-      id: c.id,
-      name: toPublicClassroomName(c),
-      displayName: c.displayName,
-      defaultGroupId: c.defaultGroupId,
-      activeGroupId: c.activeGroupId,
-      currentGroupId,
-      currentGroupSource,
-      createdAt: c.createdAt?.toISOString() ?? null,
-      updatedAt: c.updatedAt?.toISOString() ?? null,
-    };
+    return presentClassroomBase({ classroom: c, scheduleGroupId });
   }),
 
   listMachines: tenantProcedure
@@ -668,33 +363,11 @@ export const classroomsRouter = router({
         .where(eq(classrooms.id, input.id))
         .returning();
 
-      const currentOneOffScheduleGroupId = await getCurrentOneOffScheduleGroupId({
-        classroomId: updated.id,
-      });
-      const currentScheduleGroupId = await getCurrentScheduleGroupId({ classroomId: updated.id });
-
-      const currentGroup = resolveCurrentGroup({
-        activeGroupId: updated.activeGroupId ?? null,
-        scheduleGroupId: currentOneOffScheduleGroupId ?? currentScheduleGroupId,
-        defaultGroupId: updated.defaultGroupId ?? null,
-      });
-      const currentGroupId = currentGroup.id;
-      const currentGroupSource = currentGroup.source;
+      const scheduleGroupId = await getCurrentScheduleGroupId({ classroomId: updated.id });
 
       await notifyOpenPathClassroomChanged(updated.id);
 
-      // Serialize Date fields for JSON compatibility
-      return {
-        id: updated.id,
-        name: toPublicClassroomName(updated),
-        displayName: updated.displayName,
-        defaultGroupId: updated.defaultGroupId,
-        activeGroupId: updated.activeGroupId,
-        currentGroupId,
-        currentGroupSource,
-        createdAt: updated.createdAt?.toISOString() ?? null,
-        updatedAt: updated.updatedAt?.toISOString() ?? null,
-      };
+      return presentClassroomBase({ classroom: updated, scheduleGroupId });
     }),
 
   deleteMachine: tenantProcedure
@@ -760,31 +433,9 @@ export const classroomsRouter = router({
       classroomId: classroom.id,
     });
 
-    const currentOneOffScheduleGroupId = await getCurrentOneOffScheduleGroupId({
-      classroomId: classroom.id,
-    });
-    const currentScheduleGroupId = await getCurrentScheduleGroupId({ classroomId: classroom.id });
+    const scheduleGroupId = await getCurrentScheduleGroupId({ classroomId: classroom.id });
 
-    const currentGroup = resolveCurrentGroup({
-      activeGroupId: classroom.activeGroupId ?? null,
-      scheduleGroupId: currentOneOffScheduleGroupId ?? currentScheduleGroupId,
-      defaultGroupId: classroom.defaultGroupId ?? null,
-    });
-    const currentGroupId = currentGroup.id;
-    const currentGroupSource = currentGroup.source;
-
-    // Serialize Date fields for JSON compatibility
-    return {
-      id: classroom.id,
-      name: toPublicClassroomName(classroom),
-      displayName: classroom.displayName,
-      defaultGroupId: classroom.defaultGroupId,
-      activeGroupId: classroom.activeGroupId,
-      currentGroupId,
-      currentGroupSource,
-      createdAt: classroom.createdAt?.toISOString() ?? null,
-      updatedAt: classroom.updatedAt?.toISOString() ?? null,
-    };
+    return presentClassroomBase({ classroom, scheduleGroupId });
   }),
 
   update: tenantProcedure.input(UpdateClassroomSchema).mutation(async ({ ctx, input }) => {
@@ -807,31 +458,9 @@ export const classroomsRouter = router({
       await notifyOpenPathClassroomChanged(updated.id);
     }
 
-    const currentOneOffScheduleGroupId = await getCurrentOneOffScheduleGroupId({
-      classroomId: updated.id,
-    });
-    const currentScheduleGroupId = await getCurrentScheduleGroupId({ classroomId: updated.id });
+    const scheduleGroupId = await getCurrentScheduleGroupId({ classroomId: updated.id });
 
-    const currentGroup = resolveCurrentGroup({
-      activeGroupId: updated.activeGroupId ?? null,
-      scheduleGroupId: currentOneOffScheduleGroupId ?? currentScheduleGroupId,
-      defaultGroupId: updated.defaultGroupId ?? null,
-    });
-    const currentGroupId = currentGroup.id;
-    const currentGroupSource = currentGroup.source;
-
-    // Serialize Date fields for JSON compatibility
-    return {
-      id: updated.id,
-      name: toPublicClassroomName(updated),
-      displayName: updated.displayName,
-      defaultGroupId: updated.defaultGroupId,
-      activeGroupId: updated.activeGroupId,
-      currentGroupId,
-      currentGroupSource,
-      createdAt: updated.createdAt?.toISOString() ?? null,
-      updatedAt: updated.updatedAt?.toISOString() ?? null,
-    };
+    return presentClassroomBase({ classroom: updated, scheduleGroupId });
   }),
 
   delete: tenantProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {

--- a/api/src/trpc/routers/schedules.ts
+++ b/api/src/trpc/routers/schedules.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
@@ -13,6 +12,8 @@ import {
   notifyOpenPathClassroomChanged,
 } from '../../db/openpath.js';
 
+import { normalizeTimeHHMM, parseTimeToMinutes } from '../../services/current-group.service.js';
+
 import {
   assertCanUseGroup,
   assertOrgClassroomAccess,
@@ -21,24 +22,8 @@ import {
   requireTeacherOrAdmin,
 } from '../../lib/tenant-access.js';
 
-function normalizeTime(t: string): string {
-  const parts = t.split(':');
-  const hh = parts[0];
-  const mm = parts[1];
-  if (hh !== undefined && mm !== undefined) return `${hh}:${mm}`;
-  return t;
-}
-
 function weeklyRecurrenceWhereClause() {
   return or(eq(schedules.recurrence, 'weekly'), isNull(schedules.recurrence));
-}
-
-function parseTimeToMinutes(t: string): number {
-  const [hh, mm] = t.split(':');
-  const h = Number(hh);
-  const m = Number(mm);
-  if (!Number.isInteger(h) || !Number.isInteger(m)) return NaN;
-  return h * 60 + m;
 }
 
 function assertQuarterHour(t: string, field: string): void {
@@ -83,20 +68,24 @@ async function assertNoOneOffConflict(params: {
 }): Promise<void> {
   const { classroomId, startAt, endAt, excludeId } = params;
 
-  const clauses: any[] = [
-    eq(schedules.classroomId, classroomId),
-    eq(schedules.recurrence, 'one_off'),
-    sql`${schedules.startAt} < ${endAt} AND ${schedules.endAt} > ${startAt}`,
-  ];
-
-  if (excludeId) {
-    clauses.push(sql`${schedules.id} != ${excludeId}::uuid`);
-  }
+  const conditions =
+    excludeId !== undefined
+      ? and(
+          eq(schedules.classroomId, classroomId),
+          eq(schedules.recurrence, 'one_off'),
+          sql`${schedules.startAt} < ${endAt} AND ${schedules.endAt} > ${startAt}`,
+          sql`${schedules.id} != ${excludeId}::uuid`
+        )
+      : and(
+          eq(schedules.classroomId, classroomId),
+          eq(schedules.recurrence, 'one_off'),
+          sql`${schedules.startAt} < ${endAt} AND ${schedules.endAt} > ${startAt}`
+        );
 
   const conflicts = await openpathDb
     .select({ id: schedules.id })
     .from(schedules)
-    .where(and(...clauses))
+    .where(conditions)
     .limit(1);
 
   if (conflicts.length) {
@@ -116,20 +105,27 @@ async function assertNoConflict(params: {
 }): Promise<void> {
   const { classroomId, dayOfWeek, startTime, endTime, excludeId } = params;
 
-  const clauses: any[] = [
-    eq(schedules.classroomId, classroomId),
-    eq(schedules.dayOfWeek, dayOfWeek),
-    sql`(${startTime}::time, ${endTime}::time) OVERLAPS (${schedules.startTime}, ${schedules.endTime})`,
-  ];
-
-  if (excludeId) {
-    clauses.push(sql`${schedules.id} != ${excludeId}::uuid`);
-  }
+  const overlaps = sql`(${startTime}::time, ${endTime}::time) OVERLAPS (${schedules.startTime}, ${schedules.endTime})`;
+  const conditions =
+    excludeId !== undefined
+      ? and(
+          eq(schedules.classroomId, classroomId),
+          weeklyRecurrenceWhereClause(),
+          eq(schedules.dayOfWeek, dayOfWeek),
+          overlaps,
+          sql`${schedules.id} != ${excludeId}::uuid`
+        )
+      : and(
+          eq(schedules.classroomId, classroomId),
+          weeklyRecurrenceWhereClause(),
+          eq(schedules.dayOfWeek, dayOfWeek),
+          overlaps
+        );
 
   const conflicts = await openpathDb
     .select({ id: schedules.id })
     .from(schedules)
-    .where(and(...clauses))
+    .where(conditions)
     .limit(1);
 
   if (conflicts.length) {
@@ -138,6 +134,41 @@ async function assertNoConflict(params: {
       message: 'Ese tramo horario ya esta reservado',
     });
   }
+}
+
+type DbSchedule = typeof schedules.$inferSelect;
+
+function mapToWeeklyScheduleBase(s: DbSchedule) {
+  if (s.dayOfWeek === null || s.startTime === null || s.endTime === null) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Invalid weekly schedule row' });
+  }
+
+  return {
+    id: s.id,
+    classroomId: s.classroomId,
+    dayOfWeek: s.dayOfWeek,
+    startTime: normalizeTimeHHMM(s.startTime),
+    endTime: normalizeTimeHHMM(s.endTime),
+    groupId: s.groupId,
+    teacherId: s.teacherId,
+    recurrence: s.recurrence ?? 'weekly',
+    createdAt: s.createdAt?.toISOString?.() ?? new Date().toISOString(),
+    updatedAt: s.updatedAt?.toISOString?.() ?? undefined,
+  };
+}
+
+function mapToOneOffScheduleBase(s: DbSchedule) {
+  return {
+    id: s.id,
+    classroomId: s.classroomId,
+    startAt: s.startAt?.toISOString?.() ?? null,
+    endAt: s.endAt?.toISOString?.() ?? null,
+    groupId: s.groupId,
+    teacherId: s.teacherId,
+    recurrence: 'one_off' as const,
+    createdAt: s.createdAt?.toISOString?.() ?? new Date().toISOString(),
+    updatedAt: s.updatedAt?.toISOString?.() ?? undefined,
+  };
 }
 
 const CreateScheduleSchema = z.object({
@@ -156,7 +187,7 @@ const CreateOneOffScheduleSchema = z.object({
 });
 
 const UpdateScheduleSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().uuid(),
   dayOfWeek: z.number().int().min(1).max(5).optional(),
   startTime: z
     .string()
@@ -170,7 +201,7 @@ const UpdateScheduleSchema = z.object({
 });
 
 const UpdateOneOffScheduleSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().uuid(),
   startAt: z.string().min(1).optional(),
   endAt: z.string().min(1).optional(),
   groupId: z.string().min(1).optional(),
@@ -193,13 +224,13 @@ export const schedulesRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Classroom not found' });
       }
 
-      const rows = await openpathDb
+      const rows: DbSchedule[] = await openpathDb
         .select()
         .from(schedules)
         .where(and(eq(schedules.classroomId, input.classroomId), weeklyRecurrenceWhereClause()))
         .orderBy(schedules.dayOfWeek, schedules.startTime);
 
-      const oneOffRows = await openpathDb
+      const oneOffRows: DbSchedule[] = await openpathDb
         .select()
         .from(schedules)
         .where(
@@ -216,33 +247,16 @@ export const schedulesRouter = router({
           name: classroom[0].name,
           displayName: classroom[0].displayName,
         },
-        schedules: rows.map((s: any) => ({
-          id: s.id,
-          classroomId: s.classroomId,
-          dayOfWeek: s.dayOfWeek,
-          startTime: normalizeTime(s.startTime),
-          endTime: normalizeTime(s.endTime),
-          groupId: s.groupId,
-          teacherId: s.teacherId,
-          recurrence: s.recurrence ?? 'weekly',
-          createdAt: s.createdAt?.toISOString?.() ?? new Date().toISOString(),
-          updatedAt: s.updatedAt?.toISOString?.() ?? undefined,
-          isMine: s.teacherId === userId,
-          canEdit: s.teacherId === userId || admin,
-        })),
-        oneOffSchedules: oneOffRows.map((s: any) => ({
-          id: s.id,
-          classroomId: s.classroomId,
-          startAt: s.startAt?.toISOString?.() ?? null,
-          endAt: s.endAt?.toISOString?.() ?? null,
-          groupId: s.groupId,
-          teacherId: s.teacherId,
-          recurrence: 'one_off',
-          createdAt: s.createdAt?.toISOString?.() ?? new Date().toISOString(),
-          updatedAt: s.updatedAt?.toISOString?.() ?? undefined,
-          isMine: s.teacherId === userId,
-          canEdit: s.teacherId === userId || admin,
-        })),
+        schedules: rows.map((s) => {
+          const base = mapToWeeklyScheduleBase(s);
+          const isMine = base.teacherId === userId;
+          return { ...base, isMine, canEdit: isMine || admin };
+        }),
+        oneOffSchedules: oneOffRows.map((s) => {
+          const base = mapToOneOffScheduleBase(s);
+          const isMine = base.teacherId === userId;
+          return { ...base, isMine, canEdit: isMine || admin };
+        }),
       };
     }),
 
@@ -257,7 +271,7 @@ export const schedulesRouter = router({
     const classroomIds = orgClassrooms.map((oc) => oc.classroomId);
     if (classroomIds.length === 0) return [];
 
-    const rows = await openpathDb
+    const rows: DbSchedule[] = await openpathDb
       .select()
       .from(schedules)
       .where(
@@ -269,18 +283,7 @@ export const schedulesRouter = router({
       )
       .orderBy(schedules.dayOfWeek, schedules.startTime);
 
-    return rows.map((s: any) => ({
-      id: s.id,
-      classroomId: s.classroomId,
-      dayOfWeek: s.dayOfWeek,
-      startTime: normalizeTime(s.startTime),
-      endTime: normalizeTime(s.endTime),
-      groupId: s.groupId,
-      teacherId: s.teacherId,
-      recurrence: s.recurrence ?? 'weekly',
-      createdAt: s.createdAt?.toISOString?.() ?? new Date().toISOString(),
-      updatedAt: s.updatedAt?.toISOString?.() ?? undefined,
-    }));
+    return rows.map(mapToWeeklyScheduleBase);
   }),
 
   create: tenantProcedure.input(CreateScheduleSchema).mutation(async ({ ctx, input }) => {
@@ -315,28 +318,17 @@ export const schedulesRouter = router({
         teacherId: ctx.user.sub,
         groupId: input.groupId,
         dayOfWeek: input.dayOfWeek,
-        startTime: input.startTime as any,
-        endTime: input.endTime as any,
+        startTime: input.startTime,
+        endTime: input.endTime,
         startAt: null,
         endAt: null,
         recurrence: 'weekly',
-      } as any)
+      })
       .returning();
 
     await notifyOpenPathClassroomChanged(created.classroomId);
 
-    return {
-      id: created.id,
-      classroomId: created.classroomId,
-      dayOfWeek: created.dayOfWeek,
-      startTime: normalizeTime(created.startTime),
-      endTime: normalizeTime(created.endTime),
-      groupId: created.groupId,
-      teacherId: created.teacherId,
-      recurrence: created.recurrence ?? 'weekly',
-      createdAt: created.createdAt?.toISOString?.() ?? new Date().toISOString(),
-      updatedAt: created.updatedAt?.toISOString?.() ?? undefined,
-    };
+    return mapToWeeklyScheduleBase(created as DbSchedule);
   }),
 
   createOneOff: tenantProcedure
@@ -375,56 +367,59 @@ export const schedulesRouter = router({
           dayOfWeek: null,
           startTime: null,
           endTime: null,
-          startAt: startAt as any,
-          endAt: endAt as any,
+          startAt,
+          endAt,
           recurrence: 'one_off',
-        } as any)
+        })
         .returning();
 
       await notifyOpenPathClassroomChanged(created.classroomId);
 
-      return {
-        id: created.id,
-        classroomId: created.classroomId,
-        startAt: created.startAt?.toISOString?.() ?? null,
-        endAt: created.endAt?.toISOString?.() ?? null,
-        groupId: created.groupId,
-        teacherId: created.teacherId,
-        recurrence: 'one_off',
-        createdAt: created.createdAt?.toISOString?.() ?? new Date().toISOString(),
-        updatedAt: created.updatedAt?.toISOString?.() ?? undefined,
-      };
+      return mapToOneOffScheduleBase(created as DbSchedule);
     }),
 
   update: tenantProcedure.input(UpdateScheduleSchema).mutation(async ({ ctx, input }) => {
     requireTeacherOrAdmin(ctx);
 
-    const existing = await openpathDb
+    const existing: DbSchedule[] = await openpathDb
       .select()
       .from(schedules)
-      .where(eq(schedules.id, input.id as any))
+      .where(eq(schedules.id, input.id))
       .limit(1);
 
-    if (!existing[0]) {
+    const schedule = existing[0];
+    if (!schedule) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Schedule not found' });
     }
 
-    await assertOrgClassroomAccess(ctx.organizationId!, existing[0].classroomId);
+    if (schedule.recurrence === 'one_off') {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Schedule is not weekly' });
+    }
+
+    const baseDayOfWeek = schedule.dayOfWeek;
+    const baseStartTime = schedule.startTime;
+    const baseEndTime = schedule.endTime;
+
+    if (baseDayOfWeek === null || baseStartTime === null || baseEndTime === null) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid weekly schedule' });
+    }
+
+    await assertOrgClassroomAccess(ctx.organizationId!, schedule.classroomId);
 
     const admin = isOrgAdmin(ctx);
-    const isOwner = existing[0].teacherId === ctx.user.sub;
+    const isOwner = schedule.teacherId === ctx.user.sub;
     if (!admin && !isOwner) {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'You can only manage your own schedules' });
     }
 
-    const nextDayOfWeek = input.dayOfWeek ?? existing[0].dayOfWeek;
-    const nextStart = input.startTime ?? normalizeTime(existing[0].startTime);
-    const nextEnd = input.endTime ?? normalizeTime(existing[0].endTime);
-    const nextGroupId = input.groupId ?? existing[0].groupId;
+    const nextDayOfWeek = input.dayOfWeek ?? baseDayOfWeek;
+    const nextStart = input.startTime ?? normalizeTimeHHMM(baseStartTime);
+    const nextEnd = input.endTime ?? normalizeTimeHHMM(baseEndTime);
+    const nextGroupId = input.groupId ?? schedule.groupId;
 
     await assertOrgGroupAccess(ctx.organizationId!, nextGroupId);
 
-    if (input.groupId !== undefined && input.groupId !== existing[0].groupId) {
+    if (input.groupId !== undefined && input.groupId !== schedule.groupId) {
       await assertCanUseGroup(ctx, input.groupId, {
         notAllowedMessage: 'You can only create schedules for your assigned groups',
       });
@@ -439,41 +434,45 @@ export const schedulesRouter = router({
     }
 
     await assertNoConflict({
-      classroomId: existing[0].classroomId,
+      classroomId: schedule.classroomId,
       dayOfWeek: nextDayOfWeek,
       startTime: nextStart,
       endTime: nextEnd,
       excludeId: input.id,
     });
 
+    const updateValues: Partial<typeof schedules.$inferInsert> = {
+      startAt: null,
+      endAt: null,
+      updatedAt: new Date(),
+    };
+
+    if (input.dayOfWeek !== undefined) {
+      updateValues.dayOfWeek = input.dayOfWeek;
+    }
+    if (input.startTime !== undefined) {
+      updateValues.startTime = input.startTime;
+    }
+    if (input.endTime !== undefined) {
+      updateValues.endTime = input.endTime;
+    }
+    if (input.groupId !== undefined) {
+      updateValues.groupId = input.groupId;
+    }
+
     const [updated] = await openpathDb
       .update(schedules)
-      .set({
-        dayOfWeek: input.dayOfWeek,
-        startTime: input.startTime as any,
-        endTime: input.endTime as any,
-        groupId: input.groupId,
-        startAt: null,
-        endAt: null,
-        updatedAt: new Date(),
-      } as any)
-      .where(eq(schedules.id, input.id as any))
+      .set(updateValues)
+      .where(eq(schedules.id, input.id))
       .returning();
+
+    if (!updated) {
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update schedule' });
+    }
 
     await notifyOpenPathClassroomChanged(updated.classroomId);
 
-    return {
-      id: updated.id,
-      classroomId: updated.classroomId,
-      dayOfWeek: updated.dayOfWeek,
-      startTime: normalizeTime(updated.startTime),
-      endTime: normalizeTime(updated.endTime),
-      groupId: updated.groupId,
-      teacherId: updated.teacherId,
-      recurrence: updated.recurrence ?? 'weekly',
-      createdAt: updated.createdAt?.toISOString?.() ?? new Date().toISOString(),
-      updatedAt: updated.updatedAt?.toISOString?.() ?? undefined,
-    };
+    return mapToWeeklyScheduleBase(updated as DbSchedule);
   }),
 
   updateOneOff: tenantProcedure
@@ -481,24 +480,25 @@ export const schedulesRouter = router({
     .mutation(async ({ ctx, input }) => {
       requireTeacherOrAdmin(ctx);
 
-      const existing = await openpathDb
+      const existing: DbSchedule[] = await openpathDb
         .select()
         .from(schedules)
-        .where(eq(schedules.id, input.id as any))
+        .where(eq(schedules.id, input.id))
         .limit(1);
 
-      if (!existing[0]) {
+      const schedule = existing[0];
+      if (!schedule) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Schedule not found' });
       }
 
-      if (existing[0].recurrence !== 'one_off') {
+      if (schedule.recurrence !== 'one_off') {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Schedule is not one-off' });
       }
 
-      await assertOrgClassroomAccess(ctx.organizationId!, existing[0].classroomId);
+      await assertOrgClassroomAccess(ctx.organizationId!, schedule.classroomId);
 
       const admin = isOrgAdmin(ctx);
-      const isOwner = existing[0].teacherId === ctx.user.sub;
+      const isOwner = schedule.teacherId === ctx.user.sub;
       if (!admin && !isOwner) {
         throw new TRPCError({
           code: 'FORBIDDEN',
@@ -506,17 +506,17 @@ export const schedulesRouter = router({
         });
       }
 
-      const nextGroupId = input.groupId ?? existing[0].groupId;
+      const nextGroupId = input.groupId ?? schedule.groupId;
       await assertOrgGroupAccess(ctx.organizationId!, nextGroupId);
 
-      if (input.groupId !== undefined && input.groupId !== existing[0].groupId) {
+      if (input.groupId !== undefined && input.groupId !== schedule.groupId) {
         await assertCanUseGroup(ctx, input.groupId, {
           notAllowedMessage: 'You can only create schedules for your assigned groups',
         });
       }
 
-      const baseStartAt = existing[0].startAt;
-      const baseEndAt = existing[0].endAt;
+      const baseStartAt = schedule.startAt;
+      const baseEndAt = schedule.endAt;
       if (!baseStartAt || !baseEndAt) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid one-off schedule' });
       }
@@ -531,57 +531,64 @@ export const schedulesRouter = router({
       }
 
       await assertNoOneOffConflict({
-        classroomId: existing[0].classroomId,
+        classroomId: schedule.classroomId,
         startAt: nextStartAt,
         endAt: nextEndAt,
         excludeId: input.id,
       });
 
+      const updateValues: Partial<typeof schedules.$inferInsert> = {
+        updatedAt: new Date(),
+      };
+
+      if (input.groupId !== undefined) {
+        updateValues.groupId = input.groupId;
+      }
+      if (input.startAt !== undefined) {
+        updateValues.startAt = nextStartAt;
+      }
+      if (input.endAt !== undefined) {
+        updateValues.endAt = nextEndAt;
+      }
+
       const [updated] = await openpathDb
         .update(schedules)
-        .set({
-          groupId: input.groupId,
-          startAt: input.startAt ? (nextStartAt as any) : undefined,
-          endAt: input.endAt ? (nextEndAt as any) : undefined,
-          updatedAt: new Date(),
-        } as any)
-        .where(eq(schedules.id, input.id as any))
+        .set(updateValues)
+        .where(eq(schedules.id, input.id))
         .returning();
+
+      if (!updated) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update schedule',
+        });
+      }
 
       await notifyOpenPathClassroomChanged(updated.classroomId);
 
-      return {
-        id: updated.id,
-        classroomId: updated.classroomId,
-        startAt: updated.startAt?.toISOString?.() ?? null,
-        endAt: updated.endAt?.toISOString?.() ?? null,
-        groupId: updated.groupId,
-        teacherId: updated.teacherId,
-        recurrence: 'one_off',
-        createdAt: updated.createdAt?.toISOString?.() ?? new Date().toISOString(),
-        updatedAt: updated.updatedAt?.toISOString?.() ?? undefined,
-      };
+      return mapToOneOffScheduleBase(updated as DbSchedule);
     }),
 
   delete: tenantProcedure
-    .input(z.object({ id: z.string().min(1) }))
+    .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       requireTeacherOrAdmin(ctx);
 
-      const existing = await openpathDb
+      const existing: DbSchedule[] = await openpathDb
         .select()
         .from(schedules)
-        .where(eq(schedules.id, input.id as any))
+        .where(eq(schedules.id, input.id))
         .limit(1);
 
-      if (!existing[0]) {
+      const schedule = existing[0];
+      if (!schedule) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Schedule not found' });
       }
 
-      await assertOrgClassroomAccess(ctx.organizationId!, existing[0].classroomId);
+      await assertOrgClassroomAccess(ctx.organizationId!, schedule.classroomId);
 
       const admin = isOrgAdmin(ctx);
-      const isOwner = existing[0].teacherId === ctx.user.sub;
+      const isOwner = schedule.teacherId === ctx.user.sub;
       if (!admin && !isOwner) {
         throw new TRPCError({
           code: 'FORBIDDEN',
@@ -589,9 +596,9 @@ export const schedulesRouter = router({
         });
       }
 
-      await openpathDb.delete(schedules).where(eq(schedules.id, input.id as any));
+      await openpathDb.delete(schedules).where(eq(schedules.id, input.id));
 
-      await notifyOpenPathClassroomChanged(existing[0].classroomId);
+      await notifyOpenPathClassroomChanged(schedule.classroomId);
       return { success: true };
     }),
 });

--- a/api/tests/classroom-presenter.test.ts
+++ b/api/tests/classroom-presenter.test.ts
@@ -1,0 +1,160 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  groupMachinesByClassroomIdForList,
+  presentClassroomBase,
+  presentClassroomListItem,
+  presentMachineForClassroomList,
+  toPublicClassroomName,
+  type ClassroomMachineListItem,
+} from '../src/services/classroom-presenter.js';
+
+describe('classroom-presenter', () => {
+  describe('toPublicClassroomName', () => {
+    it('prefers displayName when present', () => {
+      assert.strictEqual(
+        toPublicClassroomName({ name: 'cp-deadbeef00-room-0123abcd', displayName: 'Room A' }),
+        'Room A'
+      );
+    });
+
+    it('extracts name from scoped classroom name when no displayName', () => {
+      assert.strictEqual(
+        toPublicClassroomName({ name: 'cp-0123456789-lab-abcdef12', displayName: null }),
+        'lab'
+      );
+    });
+  });
+
+  describe('presentMachineForClassroomList', () => {
+    it('returns null when machine is not assigned to a classroom', () => {
+      const now = new Date('2025-01-01T00:00:00.000Z');
+      const item = presentMachineForClassroomList(
+        {
+          id: 'm1',
+          hostname: 'pc-1',
+          classroomId: null,
+          version: '1.0.0',
+          lastSeen: now,
+        },
+        now
+      );
+      assert.strictEqual(item, null);
+    });
+
+    it('computes status and serializes lastSeen', () => {
+      const now = new Date('2025-01-01T00:00:00.000Z');
+      const lastSeen = new Date(now.getTime() - 10 * 60 * 1000);
+      const item = presentMachineForClassroomList(
+        {
+          id: 'm2',
+          hostname: 'pc-2',
+          classroomId: 'c1',
+          version: null,
+          lastSeen,
+        },
+        now
+      );
+
+      assert.ok(item);
+      assert.strictEqual(item.classroomId, 'c1');
+      assert.strictEqual(item.lastSeen, lastSeen.toISOString());
+      assert.strictEqual(item.status, 'stale');
+    });
+  });
+
+  describe('groupMachinesByClassroomIdForList', () => {
+    it('groups machines by classroomId and skips unassigned machines', () => {
+      const now = new Date('2025-01-01T00:00:00.000Z');
+      const rows = [
+        {
+          id: 'm1',
+          hostname: 'pc-1',
+          classroomId: 'c1',
+          version: null,
+          lastSeen: now,
+        },
+        {
+          id: 'm2',
+          hostname: 'pc-2',
+          classroomId: 'c1',
+          version: null,
+          lastSeen: now,
+        },
+        {
+          id: 'm3',
+          hostname: 'pc-3',
+          classroomId: null,
+          version: null,
+          lastSeen: now,
+        },
+      ];
+
+      const map = groupMachinesByClassroomIdForList(rows, now);
+      assert.strictEqual(map.size, 1);
+      assert.strictEqual(map.get('c1')?.length, 2);
+    });
+  });
+
+  describe('presentClassroomBase', () => {
+    it('computes currentGroupId/currentGroupSource using schedule fallback', () => {
+      const classroom = {
+        id: 'c1',
+        name: 'cp-0123456789-lab-abcdef12',
+        displayName: null,
+        defaultGroupId: null,
+        activeGroupId: null,
+        createdAt: new Date('2025-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2025-01-02T00:00:00.000Z'),
+      };
+
+      const presented = presentClassroomBase({ classroom, scheduleGroupId: 'g-schedule' });
+      assert.strictEqual(presented.currentGroupId, 'g-schedule');
+      assert.strictEqual(presented.currentGroupSource, 'schedule');
+    });
+  });
+
+  describe('presentClassroomListItem', () => {
+    it('computes classroom status and counts', () => {
+      const classroom = {
+        id: 'c1',
+        name: 'cp-0123456789-lab-abcdef12',
+        displayName: 'Lab',
+        defaultGroupId: null,
+        activeGroupId: null,
+        createdAt: null,
+        updatedAt: null,
+      };
+
+      const machines: ClassroomMachineListItem[] = [
+        {
+          id: 'm1',
+          hostname: 'pc-1',
+          classroomId: 'c1',
+          version: null,
+          lastSeen: null,
+          status: 'online',
+        },
+        {
+          id: 'm2',
+          hostname: 'pc-2',
+          classroomId: 'c1',
+          version: null,
+          lastSeen: null,
+          status: 'offline',
+        },
+      ];
+
+      const presented = presentClassroomListItem({
+        classroom,
+        scheduleGroupId: null,
+        machines,
+      });
+
+      assert.strictEqual(presented.machineCount, 2);
+      assert.strictEqual(presented.onlineMachineCount, 1);
+      assert.strictEqual(presented.status, 'degraded');
+    });
+  });
+});

--- a/api/tests/current-group.service.test.ts
+++ b/api/tests/current-group.service.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { TRPCError } from '@trpc/server';
+
+import {
+  calculateWeeklyScheduleExpiresAt,
+  normalizeTimeHHMM,
+  parseTimeToMinutes,
+} from '../src/services/current-group.service.js';
+
+describe('current-group.service', () => {
+  describe('normalizeTimeHHMM', () => {
+    it('keeps HH:MM unchanged', () => {
+      assert.strictEqual(normalizeTimeHHMM('09:30'), '09:30');
+    });
+
+    it('trims seconds from HH:MM:SS', () => {
+      assert.strictEqual(normalizeTimeHHMM('09:30:00'), '09:30');
+    });
+
+    it('stringifies null input', () => {
+      assert.strictEqual(normalizeTimeHHMM(null), 'null');
+    });
+  });
+
+  describe('parseTimeToMinutes', () => {
+    it('parses valid HH:MM', () => {
+      assert.strictEqual(parseTimeToMinutes('00:00'), 0);
+      assert.strictEqual(parseTimeToMinutes('10:15'), 615);
+      assert.strictEqual(parseTimeToMinutes('23:59'), 23 * 60 + 59);
+    });
+
+    it('returns NaN for invalid input', () => {
+      assert.ok(Number.isNaN(parseTimeToMinutes('not-a-time')));
+    });
+  });
+
+  describe('calculateWeeklyScheduleExpiresAt', () => {
+    it('returns schedule end aligned to minute boundary', () => {
+      const now = new Date('2025-01-01T10:05:30.500Z');
+
+      const expiresAt = calculateWeeklyScheduleExpiresAt({
+        now,
+        nowTimeHHMM: '10:05',
+        endTime: '10:15:00',
+      });
+
+      assert.strictEqual(expiresAt.toISOString(), '2025-01-01T10:15:00.000Z');
+    });
+
+    it('throws BAD_REQUEST when endTime is not after nowTime', () => {
+      const now = new Date('2025-01-01T10:05:30.500Z');
+
+      assert.throws(
+        () =>
+          calculateWeeklyScheduleExpiresAt({
+            now,
+            nowTimeHHMM: '10:05',
+            endTime: '10:05:00',
+          }),
+        (err: unknown) => {
+          assert.ok(err instanceof TRPCError);
+          assert.strictEqual(err.code, 'BAD_REQUEST');
+          assert.strictEqual(err.message, 'Invalid schedule end time');
+          return true;
+        }
+      );
+    });
+  });
+});

--- a/api/tests/tenant-access.test.ts
+++ b/api/tests/tenant-access.test.ts
@@ -11,6 +11,7 @@ import {
   assertCanViewGroup,
   assertOrgClassroomAccess,
   assertOrgGroupAccess,
+  getOrgGroupLinkOrThrow,
   getOrgClassroomLinkOrThrow,
   getAccessibleTenantGroupIds,
   getTeacherGroupIdentifiers,
@@ -200,6 +201,23 @@ describe('tenant-access', () => {
     try {
       await assertOrgGroupAccess(ORG_ID, 'missing');
       assert.fail('expected assertOrgGroupAccess to throw');
+    } catch (err) {
+      assertTrpcError(err, 'NOT_FOUND', 'Group not found or access denied');
+    }
+  });
+
+  it('getOrgGroupLinkOrThrow returns cpOrganizationGroups id + visibility', async () => {
+    const linkPublic = await getOrgGroupLinkOrThrow(ORG_ID, GROUP_ID_3);
+    assert.strictEqual(linkPublic.id, `og_${RUN_ID}_3`);
+    assert.strictEqual(linkPublic.visibility, 'instance_public');
+
+    const linkPrivate = await getOrgGroupLinkOrThrow(ORG_ID, GROUP_ID);
+    assert.strictEqual(linkPrivate.id, `og_${RUN_ID}_1`);
+    assert.strictEqual(linkPrivate.visibility, 'private');
+
+    try {
+      await getOrgGroupLinkOrThrow(ORG_ID, 'missing');
+      assert.fail('expected getOrgGroupLinkOrThrow to throw');
     } catch (err) {
       assertTrpcError(err, 'NOT_FOUND', 'Group not found or access denied');
     }


### PR DESCRIPTION
## What
- Extracted schedule/current-group + time helpers into `api/src/services/current-group.service.ts` and reused them.
- Extracted classroom list/detail presenter logic into `api/src/services/classroom-presenter.ts` and slimmed `api/src/trpc/routers/classrooms.ts`.
- Removed `// @ts-nocheck` from `api/src/trpc/routers/schedules.ts` by adding nullability guards and using Drizzle-inferred types.
- Extended the tenant-access `getOrThrow` pattern to org-group access to reduce duplicated lookups.

## Why
- Improves maintainability by keeping routers as orchestration and concentrating business/presentation logic in testable services.
- Reduces type drift and catches nullability issues at compile time.

## Verification
- Pre-commit `verify:full` passed (build, lint/format, security checks, API+SPA tests, API coverage gate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added timezone-aware schedule resolution for accurate current schedule determination.
  * Implemented one-off schedule prioritization over weekly schedules.
  * Enhanced classroom status reporting with machine online/offline counts and detailed status tracking.

* **Improvements**
  * Strengthened schedule identification with UUID validation.
  * Consolidated classroom and machine data presentation for consistency.

* **Tests**
  * Added comprehensive test coverage for schedule resolution and classroom status utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->