### PR TITLE
fix(onboarding): allow org creation by default in production

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -147,7 +147,7 @@ export function resolveRuntimeConfig(env: RuntimeEnv = process.env): RuntimeConf
     resendFromEmail,
     mockEmailDelivery: resolveMockEmailDelivery(env),
     emailDeliveryMode: resolveEmailDeliveryMode(env),
-    allowSelfServiceOrgs: parseBooleanEnv(env.CP_ALLOW_SELF_SERVICE_ORGS, !isProduction(env)),
+    allowSelfServiceOrgs: parseBooleanEnv(env.CP_ALLOW_SELF_SERVICE_ORGS, true),
     allowOrgDirectory: parseBooleanEnv(env.CP_ALLOW_ORG_DIRECTORY, false),
   };
 }
@@ -187,7 +187,7 @@ export const config = {
     return resolveEmailDeliveryMode(process.env);
   },
   get allowSelfServiceOrgs() {
-    return parseBooleanEnv(process.env.CP_ALLOW_SELF_SERVICE_ORGS, !isProduction(process.env));
+    return parseBooleanEnv(process.env.CP_ALLOW_SELF_SERVICE_ORGS, true);
   },
   get allowOrgDirectory() {
     return parseBooleanEnv(process.env.CP_ALLOW_ORG_DIRECTORY, false);

--- a/api/tests/config.test.ts
+++ b/api/tests/config.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
 const ORIGINAL_ENV = {
+  CP_ALLOW_ORG_DIRECTORY: process.env.CP_ALLOW_ORG_DIRECTORY,
+  CP_ALLOW_SELF_SERVICE_ORGS: process.env.CP_ALLOW_SELF_SERVICE_ORGS,
   CP_FAKE_EMAIL_DELIVERY: process.env.CP_FAKE_EMAIL_DELIVERY,
   JWT_SECRET: process.env.JWT_SECRET,
   NODE_ENV: process.env.NODE_ENV,
@@ -11,6 +13,8 @@ const ORIGINAL_ENV = {
 };
 
 function restoreEnv(): void {
+  setEnv('CP_ALLOW_ORG_DIRECTORY', ORIGINAL_ENV.CP_ALLOW_ORG_DIRECTORY);
+  setEnv('CP_ALLOW_SELF_SERVICE_ORGS', ORIGINAL_ENV.CP_ALLOW_SELF_SERVICE_ORGS);
   setEnv('CP_FAKE_EMAIL_DELIVERY', ORIGINAL_ENV.CP_FAKE_EMAIL_DELIVERY);
   setEnv('JWT_SECRET', ORIGINAL_ENV.JWT_SECRET);
   setEnv('NODE_ENV', ORIGINAL_ENV.NODE_ENV);
@@ -68,6 +72,23 @@ describe('runtime config contract', () => {
     const configModule = await import(`../src/config.ts?${tag}`);
 
     assert.throws(() => configModule.resolveRuntimeConfig(), /PUBLIC_URL/i);
+  });
+
+  it('enables self-service organization creation by default in production while keeping the directory hidden', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'production-secret-value';
+    process.env.PUBLIC_URL = 'https://classroompath.eu';
+    delete process.env.CP_ALLOW_SELF_SERVICE_ORGS;
+    delete process.env.CP_ALLOW_ORG_DIRECTORY;
+
+    const tag = `runtime-config-production-onboarding-policy-${Date.now()}-${Math.random()
+      .toString(16)
+      .slice(2)}`;
+    const configModule = await import(`../src/config.ts?${tag}`);
+    const runtimeConfig = configModule.resolveRuntimeConfig();
+
+    assert.equal(runtimeConfig.allowSelfServiceOrgs, true);
+    assert.equal(runtimeConfig.allowOrgDirectory, false);
   });
 
   it('derives the email delivery mode from the runtime env contract', async () => {

--- a/api/tests/integration/onboarding-policy.integration.test.ts
+++ b/api/tests/integration/onboarding-policy.integration.test.ts
@@ -65,7 +65,7 @@ describe('ClassroomPath onboarding policy integration', { concurrency: 1 }, asyn
     restorePolicyEnv();
   });
 
-  test('disables self-service organization creation by default in production', async () => {
+  test('keeps self-service organization creation enabled by default in production while hiding the directory', async () => {
     process.env.NODE_ENV = 'production';
     delete process.env.CP_ALLOW_SELF_SERVICE_ORGS;
     delete process.env.CP_ALLOW_ORG_DIRECTORY;
@@ -75,14 +75,11 @@ describe('ClassroomPath onboarding policy integration', { concurrency: 1 }, asyn
     const response = await trpcMutate(
       integration.baseUrl,
       'onboarding.createOrganization',
-      { name: 'Blocked Production Org' },
+      { name: 'Default Production Org' },
       bearerAuth(token)
     );
 
-    assert.strictEqual(response.status, 403);
-    const parsed = (await parseTRPC(response)) as { error?: string; code?: string };
-    assert.strictEqual(parsed.code, 'FORBIDDEN');
-    assert.match(parsed.error ?? '', /self-service|crear organizaciones|disabled|deshabilitada/i);
+    assert.strictEqual(response.status, 200);
 
     const statusResponse = await trpcQuery(
       integration.baseUrl,
@@ -96,8 +93,20 @@ describe('ClassroomPath onboarding policy integration', { concurrency: 1 }, asyn
         policy?: { allowSelfServiceOrgs?: boolean; allowOrgDirectory?: boolean };
       };
     };
-    assert.strictEqual(statusParsed.data?.policy?.allowSelfServiceOrgs, false);
+    assert.strictEqual(statusParsed.data?.policy?.allowSelfServiceOrgs, true);
     assert.strictEqual(statusParsed.data?.policy?.allowOrgDirectory, false);
+
+    const listResponse = await trpcQuery(
+      integration.baseUrl,
+      'onboarding.listOrganizations',
+      undefined,
+      bearerAuth(token)
+    );
+    assert.strictEqual(listResponse.status, 200);
+    const listParsed = (await parseTRPC(listResponse)) as {
+      data?: Array<{ id: string; name: string }>;
+    };
+    assert.deepStrictEqual(listParsed.data, []);
   });
 
   test('hides the organization directory by default in production', async () => {


### PR DESCRIPTION
## Summary
- enable self-service organization creation by default in production while keeping the organization directory hidden
- cover the runtime config contract for the production onboarding default
- update onboarding policy integration coverage for the production signup path

## Test Plan
- [x] node --import tsx --test tests/config.test.ts
- [x] NODE_ENV=test node --import tsx --test tests/integration/onboarding-policy.integration.test.ts
- [x] git commit (pre-commit hook ran verify:full)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Self-service organization creation is now enabled by default in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->